### PR TITLE
Add .gitattributes and vendor exclude .js files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js linguist-vendored


### PR DESCRIPTION
This is not a javascript project, but uses a javascript util to lint
MarkDown files.

Signed-off-by: Cullen Taylor <CullenTaylor@outlook.com>